### PR TITLE
Formalize schema, standardize on normalization process, and improve solc support

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ var TruffleSchema = {
       "binary": "bytecode",
       "srcmap": "sourceMap",
       "srcmapRuntime": "deployedSourceMap",
-      "interface": "abi"
+      "interface": "abi",
+      "runtimeBytecode": "deployedBytecode"
     };
 
     // Merge options/contract object first, then extra_options
@@ -108,10 +109,13 @@ var TruffleSchema = {
 
     obj.contract_name = obj.contract_name || "Contract";
 
-    // Ensure unlinked binary starts with a 0x
+    // Ensure bytecode/deployedBytecode start with 0x
     // TODO: Remove this and enforce it through json schema
     if (obj.bytecode && obj.bytecode.indexOf("0x") < 0) {
       obj.bytecode = "0x" + obj.bytecode;
+    }
+    if (obj.deployedBytecode && obj.deployedBytecode.indexOf("0x") < 0) {
+      obj.deployedBytecode = "0x" + obj.deployedBytecode;
     }
 
     var updated_at = new Date().getTime();

--- a/index.js
+++ b/index.js
@@ -229,10 +229,6 @@ var TruffleSchema = {
       obj.networks[network_id] = existingObj.networks[network_id];
     });
 
-    // if (options.overwrite == true) {
-    //   e = {};
-    // }
-
     obj.contractName = obj.contractName || "Contract";
 
     var updatedAt = new Date().toISOString();

--- a/index.js
+++ b/index.js
@@ -49,14 +49,15 @@ var properties = {
   },
   "bytecode": {
     "additionalSources": [
-      chain(getter("evm"), getter("bytecode"), getter("object")),
       getter("binary"),
       getter("unlinked_binary"),
+      chain(getter("evm"), getter("bytecode"), getter("object"))
     ],
     "transform": function(value) {
       if (value && value.indexOf("0x") != 0) {
-        return "0x" + value;
+        value = "0x" + value;
       }
+      return value;
     }
   },
   "deployedBytecode": {
@@ -66,8 +67,9 @@ var properties = {
     ],
     "transform": function(value) {
       if (value && value.indexOf("0x") != 0) {
-        return "0x" + value;
+        value = "0x" + value;
       }
+      return value;
     }
   },
   "sourceMap": {
@@ -82,18 +84,9 @@ var properties = {
       chain(getter("evm"), getter("deployedBytecode"), getter("sourceMap")),
     ]
   },
-  "source": {
-    "additionalSources": []
-  },
-  "sourcePath": {
-    "additionalSources": []
-  },
-  "ast": {
-    "additionalSources": []
-  },
-  "address": {
-    "additionalSources": []
-  },
+  "source": {},
+  "sourcePath": {},
+  "ast": {},
   "networks": {
     "additionalSources": [
       // can infer blank network from being given network_id
@@ -107,8 +100,9 @@ var properties = {
     ],
     "transform": function(value) {
       if (value === undefined) {
-        return {}
+        value = {}
       }
+      return value;
     }
   },
   "schemaVersion": {

--- a/index.js
+++ b/index.js
@@ -76,13 +76,6 @@ var properties = {
   "ast": {},
   "networks": {
     // infers blank network from network_id
-    "sources": ["networks", getter("network_id", function(network_id) {
-      if (network_id !== undefined) {
-        var networks = {}
-        networks[network_id] = {"events": {}, "links": {}};
-        return networks;
-      }
-    })],
     "transform": function(value) {
       if (value === undefined) {
         value = {}
@@ -94,9 +87,13 @@ var properties = {
     "sources": ["schemaVersion", "schema_version"]
   },
   "updatedAt": {
-    "sources": ["updatedAt", getter("updated_at", function(ms) {
-      return new Date(ms).toISOString()
-    })]
+    "sources": ["updatedAt", "updated_at"],
+    "transform": function(value) {
+      if (typeof value === "number") {
+        value = new Date(value).toISOString();
+      }
+      return value;
+    }
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -208,39 +208,6 @@ var TruffleContractSchema = {
     normalized.schemaVersion = pkgVersion;
 
     return normalized;
-  },
-
-  // Generate a proper binary from normalized options, and optionally
-  // merge it with an existing binary.
-  generateObject: function(objDirty, existingObjDirty, options) {
-    objDirty = objDirty || {};
-    existingObjDirty = existingObjDirty || {};
-
-    options = options || {};
-
-    obj = this.normalize(objDirty);
-    existingObj = this.normalize(existingObjDirty);
-
-    Object.keys(existingObj).forEach(function(key) {
-      // networks will be skipped because normalize replaces undefined with {}
-      if (obj[key] === undefined) {
-        obj[key] = existingObj[key];
-      }
-    });
-
-    Object.keys(existingObj.networks).forEach(function(network_id) {
-      obj.networks[network_id] = existingObj.networks[network_id];
-    });
-
-    var updatedAt = new Date().toISOString();
-
-    if (options.dirty !== false) {
-      obj.updatedAt = updatedAt;
-    } else {
-      obj.updatedAt = obj.updatedAt || updatedAt;
-    }
-
-    return obj;
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -146,15 +146,13 @@ var TruffleContractSchema = {
   // - Resolves as validated `contractObj`
   // - Rejects with list of errors from schema validator
   validate: function(contractObj) {
-    return new Promise(function (resolve, reject) {
-      var ajv = new Ajv();
-      var validate = ajv.compile(contractSchema);
-      if (validate(contractObj)) {
-        resolve(contractObj);
-      } else {
-        reject(validate.errors);
-      }
-    });
+    var ajv = new Ajv();
+    var validate = ajv.compile(contractSchema);
+    if (validate(contractObj)) {
+      return contractObj;
+    } else {
+      throw validate.errors;
+    }
   },
 
   // accepts as argument anything that can be turned into a contract object

--- a/index.js
+++ b/index.js
@@ -1,9 +1,26 @@
 var sha3 = require("crypto-js/sha3");
 var schema_version = require("./package.json").version;
+var Ajv = require("ajv");
+var contractSchema = require("./spec/contract.spec.json");
 
 // TODO: This whole thing should have a json schema.
 
 var TruffleSchema = {
+  // Return a promise to validate a contract object
+  // - Resolves as validated `contractObj`
+  // - Rejects with list of errors from schema validator
+  validateContractObject: function(contractObj) {
+    return new Promise(function (resolve, reject) {
+      var ajv = new Ajv();
+      var validate = ajv.compile(contractSchema);
+      if (validate(contractObj)) {
+        resolve(contractObj);
+      } else {
+        reject(validate.errors);
+      }
+    });
+  },
+
   // Normalize options passed in to be the exact options required
   // for truffle-contract.
   //

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function chain() {
 // Schema module
 //
 
-var TruffleSchema = {
+var TruffleContractSchema = {
   // Return a promise to validate a contract object
   // - Resolves as validated `contractObj`
   // - Rejects with list of errors from schema validator
@@ -234,7 +234,6 @@ var TruffleSchema = {
 
     var updatedAt = new Date().toISOString();
 
-
     if (options.dirty !== false) {
       obj.updatedAt = updatedAt;
     } else {
@@ -245,4 +244,4 @@ var TruffleSchema = {
   }
 };
 
-module.exports = TruffleSchema;
+module.exports = TruffleContractSchema;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-schema#readme",
   "dependencies": {
+    "ajv": "^5.1.1",
     "crypto-js": "^3.1.9-1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "crypto-js": "^3.1.9-1"
   },
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "solc": "^0.4.11"
   }
 }

--- a/spec/contract.spec.json
+++ b/spec/contract.spec.json
@@ -24,7 +24,6 @@
     "source": { "$ref": "#/definitions/Source" },
     "sourcePath": { "$ref": "#/definitions/SourcePath" },
     "ast": { "$ref": "#/definitions/AST" },
-    "address": { "$ref": "#/definitions/Address" },
     "networks": {
       "patternProperties": {
         "^[a-zA-Z0-9]+$": { "$ref": "#/definitions/Network" }
@@ -81,6 +80,7 @@
       "type": "object",
       "properties": {
         "address": { "$ref": "#/definitions/Address" },
+        "events": { "$ref": "#/definitions/EventsCollection" },
         "links": {
           "type": "object",
           "patternProperties": {
@@ -94,14 +94,15 @@
       "type": "object",
       "properties": {
         "address": { "$ref": "#/definitions/Address" },
-        "events": {
-          "type": "object",
-          "patternProperties": {
-            "^0x[a-fA-F0-9]{64}$": { "$ref": "#/definitions/Event" }
-          },
-          "additionalProperties": false
-        }
+        "events": { "$ref": "#/definitions/EventsCollection" }
       }
+    },
+    "EventsCollection": {
+      "type": "object",
+      "patternProperties": {
+        "^0x[a-fA-F0-9]{64}$": { "$ref": "#/definitions/Event" }
+      },
+      "additionalProperties": false
     },
     "Event": {
       "type": "object"

--- a/spec/contract.spec.json
+++ b/spec/contract.spec.json
@@ -37,6 +37,15 @@
       "format": "date-time"
     }
   },
+  "patternProperties": {
+    "^x-": { "anyOf": [
+      { "type": "string" },
+      { "type": "number" },
+      { "type": "object" },
+      { "type": "array" }
+    ]}
+
+  },
   "additionalProperties": false,
   "required": [
   ],

--- a/spec/contract.spec.json
+++ b/spec/contract.spec.json
@@ -47,6 +47,7 @@
   },
   "additionalProperties": false,
   "required": [
+    "abi"
   ],
   "definitions": {
     "ContractName": {

--- a/spec/contract.spec.json
+++ b/spec/contract.spec.json
@@ -1,0 +1,105 @@
+{
+  "id": "truffle-contract-schema.json",
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "contractName": { "$ref": "#/definitions/ContractName" },
+    "abi": { "$ref": "#/definitions/ABI" },
+    "bytecode": { "allOf": [
+      { "$ref": "#/definitions/Bytecode" },
+      { "description": "Bytecode sent as contract-creation transaction data" }
+    ]},
+    "deployedBytecode": { "allOf": [
+      { "$ref": "#/definitions/Bytecode" },
+      { "description": "On-chain deployed contract bytecode" }
+    ]},
+    "sourceMap": { "allOf": [
+      { "$ref": "#/definitions/SourceMap" },
+      { "description": "Source mapping for contract-creation transaction data bytecode" }
+    ]},
+    "deployedSourceMap": { "allOf": [
+      { "$ref": "#/definitions/SourceMap" },
+      { "description": "Source mapping for contract bytecode" }
+    ]},
+    "source": { "$ref": "#/definitions/Source" },
+    "sourcePath": { "$ref": "#/definitions/SourcePath" },
+    "ast": { "$ref": "#/definitions/AST" },
+    "address": { "$ref": "#/definitions/Address" },
+    "networks": {
+      "patternProperties": {
+        "^[a-zA-Z0-9]+$": { "$ref": "#/definitions/Network" }
+      },
+      "additionalProperties": false
+    },
+    "schemaVersion": { "$ref": "#/definitions/SchemaVersion" },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+  ],
+  "definitions": {
+    "ContractName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+    },
+    "Address": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]{40}$"
+    },
+    "ABI": {
+      "type": "array"
+    },
+    "Bytecode": {
+      "type": "string",
+      "pattern": "^0x0$|^0x([a-fA-F0-9]{2}|__[a-zA-Z0-9_]{38})+$"
+    },
+    "Source": {
+      "type": "string"
+    },
+    "SourceMap": {
+      "type": "string"
+    },
+    "SourcePath": {
+      "type": "string"
+    },
+    "AST": {
+      "type": "object"
+    },
+    "Network": {
+      "type": "object",
+      "properties": {
+        "address": { "$ref": "#/definitions/Address" },
+        "links": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z_][a-zA-Z0-9_]*$": { "$ref": "#/definitions/Link" }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "address": { "$ref": "#/definitions/Address" },
+        "events": {
+          "type": "object",
+          "patternProperties": {
+            "^0x[a-fA-F0-9]{64}$": { "$ref": "#/definitions/Event" }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "Event": {
+      "type": "object"
+    },
+    "SchemaVersion": {
+      "type": "string",
+      "pattern": "[0-9]+\\.[0-9]+\\.[0-9]+"
+    }
+  }
+}

--- a/test/MetaCoin.json
+++ b/test/MetaCoin.json
@@ -1017,7 +1017,6 @@
     ],
     "name": "SourceUnit"
   },
-  "address": "0x4a5092ae2f237d76f25691fff90955545ba2dc78",
   "networks": {
     "1494889277189": {
       "address": "0x657b316c4c7df70999a69c2475e59152f87a04aa",

--- a/test/MetaCoin.json
+++ b/test/MetaCoin.json
@@ -1,0 +1,1041 @@
+{
+  "contractName": "MetaCoin",
+  "abi": [
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "getBalanceInEth",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "sendCoin",
+      "outputs": [
+        {
+          "name": "sufficient",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "getBalance",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "payable": false,
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    }
+  ],
+  "bytecode": "0x6060604052341561000c57fe5b5b600160a060020a033216600090815260208190526040902061271090555b5b6102308061003b6000396000f300606060405263ffffffff60e060020a6000350416637bd703e8811461003757806390b98a1114610065578063f8b2cb4f14610098575bfe5b341561003f57fe5b610053600160a060020a03600435166100c6565b60408051918252519081900360200190f35b341561006d57fe5b610084600160a060020a036004351660243561014d565b604080519115158252519081900360200190f35b34156100a057fe5b610053600160a060020a03600435166101e5565b60408051918252519081900360200190f35b600073__ConvertLib____________________________6396e4ee3d6100eb846101e5565b60026000604051602001526040518363ffffffff1660e060020a028152600401808381526020018281526020019250505060206040518083038186803b151561013057fe5b6102c65a03f4151561013e57fe5b5050604051519150505b919050565b600160a060020a03331660009081526020819052604081205482901015610176575060006101df565b600160a060020a0333811660008181526020818152604080832080548890039055938716808352918490208054870190558351868152935191937fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef929081900390910190a35060015b92915050565b600160a060020a0381166000908152602081905260409020545b9190505600a165627a7a72305820f596963383bc39946413f0f0b34aee51796e6ae4b1b68b334f880b30a36ec6730029",
+  "deployedBytecode": "0x606060405263ffffffff60e060020a6000350416637bd703e8811461003757806390b98a1114610065578063f8b2cb4f14610098575bfe5b341561003f57fe5b610053600160a060020a03600435166100c6565b60408051918252519081900360200190f35b341561006d57fe5b610084600160a060020a036004351660243561014d565b604080519115158252519081900360200190f35b34156100a057fe5b610053600160a060020a03600435166101e5565b60408051918252519081900360200190f35b600073__ConvertLib____________________________6396e4ee3d6100eb846101e5565b60026000604051602001526040518363ffffffff1660e060020a028152600401808381526020018281526020019250505060206040518083038186803b151561013057fe5b6102c65a03f4151561013e57fe5b5050604051519150505b919050565b600160a060020a03331660009081526020819052604081205482901015610176575060006101df565b600160a060020a0333811660008181526020818152604080832080548890039055938716808352918490208054870190558351868152935191937fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef929081900390910190a35060015b92915050565b600160a060020a0381166000908152602081905260409020545b9190505600a165627a7a72305820f596963383bc39946413f0f0b34aee51796e6ae4b1b68b334f880b30a36ec6730029",
+  "sourceMap": "315:637:1:-;;;452:55;;;;;;;-1:-1:-1;;;;;485:9:1;476:19;:8;:19;;;;;;;;;;498:5;476:27;;452:55;315:637;;;;;;;",
+  "source": "pragma solidity ^0.4.4;\n\nimport \"./ConvertLib.sol\";\n\n// This is just a simple example of a coin-like contract.\n// It is not standards compatible and cannot be expected to talk to other\n// coin/token contracts. If you want to create a standards-compliant\n// token, see: https://github.com/ConsenSys/Tokens. Cheers!\n\ncontract MetaCoin {\n\tmapping (address => uint) balances;\n\n\tevent Transfer(address indexed _from, address indexed _to, uint256 _value);\n\n\tfunction MetaCoin() {\n\t\tbalances[tx.origin] = 10000;\n\t}\n\n\tfunction sendCoin(address receiver, uint amount) returns(bool sufficient) {\n\t\tif (balances[msg.sender] < amount) return false;\n\t\tbalances[msg.sender] -= amount;\n\t\tbalances[receiver] += amount;\n\t\tTransfer(msg.sender, receiver, amount);\n\t\treturn true;\n\t}\n\n\tfunction getBalanceInEth(address addr) returns(uint){\n\t\treturn ConvertLib.convert(getBalance(addr),2);\n\t}\n\n\tfunction getBalance(address addr) returns(uint) {\n\t\treturn balances[addr];\n\t}\n}\n",
+  "sourcePath": "/Users/gnidan/tmp/metacoin/contracts/MetaCoin.sol",
+  "ast": {
+    "children": [
+      {
+        "attributes": {
+          "literals": [
+            "solidity",
+            "^",
+            "0.4",
+            ".4"
+          ]
+        },
+        "id": 18,
+        "name": "PragmaDirective",
+        "src": "0:23:1"
+      },
+      {
+        "attributes": {
+          "file": "./ConvertLib.sol"
+        },
+        "id": 19,
+        "name": "ImportDirective",
+        "src": "25:26:1"
+      },
+      {
+        "attributes": {
+          "fullyImplemented": true,
+          "isLibrary": false,
+          "linearizedBaseContracts": [
+            112
+          ],
+          "name": "MetaCoin"
+        },
+        "children": [
+          {
+            "attributes": {
+              "constant": false,
+              "name": "balances",
+              "storageLocation": "default",
+              "type": "mapping(address => uint256)",
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address"
+                    },
+                    "id": 20,
+                    "name": "ElementaryTypeName",
+                    "src": "345:7:1"
+                  },
+                  {
+                    "attributes": {
+                      "name": "uint"
+                    },
+                    "id": 21,
+                    "name": "ElementaryTypeName",
+                    "src": "356:4:1"
+                  }
+                ],
+                "id": 22,
+                "name": "Mapping",
+                "src": "336:25:1"
+              }
+            ],
+            "id": 23,
+            "name": "VariableDeclaration",
+            "src": "336:34:1"
+          },
+          {
+            "attributes": {
+              "name": "Transfer"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "_from",
+                      "storageLocation": "default",
+                      "type": "address",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address"
+                        },
+                        "id": 24,
+                        "name": "ElementaryTypeName",
+                        "src": "389:7:1"
+                      }
+                    ],
+                    "id": 25,
+                    "name": "VariableDeclaration",
+                    "src": "389:21:1"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "_to",
+                      "storageLocation": "default",
+                      "type": "address",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address"
+                        },
+                        "id": 26,
+                        "name": "ElementaryTypeName",
+                        "src": "412:7:1"
+                      }
+                    ],
+                    "id": 27,
+                    "name": "VariableDeclaration",
+                    "src": "412:19:1"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": false,
+                      "name": "_value",
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint256"
+                        },
+                        "id": 28,
+                        "name": "ElementaryTypeName",
+                        "src": "433:7:1"
+                      }
+                    ],
+                    "id": 29,
+                    "name": "VariableDeclaration",
+                    "src": "433:14:1"
+                  }
+                ],
+                "id": 30,
+                "name": "ParameterList",
+                "src": "388:60:1"
+              }
+            ],
+            "id": 31,
+            "name": "EventDefinition",
+            "src": "374:75:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "MetaCoin",
+              "payable": false,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [],
+                "id": 32,
+                "name": "ParameterList",
+                "src": "469:2:1"
+              },
+              {
+                "children": [],
+                "id": 33,
+                "name": "ParameterList",
+                "src": "472:0:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "operator": "=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "mapping(address => uint256)",
+                                  "value": "balances"
+                                },
+                                "id": 34,
+                                "name": "Identifier",
+                                "src": "476:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "member_name": "origin",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "type": "tx",
+                                      "value": "tx"
+                                    },
+                                    "id": 35,
+                                    "name": "Identifier",
+                                    "src": "485:2:1"
+                                  }
+                                ],
+                                "id": 36,
+                                "name": "MemberAccess",
+                                "src": "485:9:1"
+                              }
+                            ],
+                            "id": 37,
+                            "name": "IndexAccess",
+                            "src": "476:19:1"
+                          },
+                          {
+                            "attributes": {
+                              "hexvalue": "3130303030",
+                              "subdenomination": null,
+                              "token": null,
+                              "type": "int_const 10000",
+                              "value": "10000"
+                            },
+                            "id": 38,
+                            "name": "Literal",
+                            "src": "498:5:1"
+                          }
+                        ],
+                        "id": 39,
+                        "name": "Assignment",
+                        "src": "476:27:1"
+                      }
+                    ],
+                    "id": 40,
+                    "name": "ExpressionStatement",
+                    "src": "476:27:1"
+                  }
+                ],
+                "id": 41,
+                "name": "Block",
+                "src": "472:35:1"
+              }
+            ],
+            "id": 42,
+            "name": "FunctionDefinition",
+            "src": "452:55:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "sendCoin",
+              "payable": false,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "receiver",
+                      "storageLocation": "default",
+                      "type": "address",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address"
+                        },
+                        "id": 43,
+                        "name": "ElementaryTypeName",
+                        "src": "528:7:1"
+                      }
+                    ],
+                    "id": 44,
+                    "name": "VariableDeclaration",
+                    "src": "528:16:1"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "amount",
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint"
+                        },
+                        "id": 45,
+                        "name": "ElementaryTypeName",
+                        "src": "546:4:1"
+                      }
+                    ],
+                    "id": 46,
+                    "name": "VariableDeclaration",
+                    "src": "546:11:1"
+                  }
+                ],
+                "id": 47,
+                "name": "ParameterList",
+                "src": "527:31:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "sufficient",
+                      "storageLocation": "default",
+                      "type": "bool",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bool"
+                        },
+                        "id": 48,
+                        "name": "ElementaryTypeName",
+                        "src": "567:4:1"
+                      }
+                    ],
+                    "id": 49,
+                    "name": "VariableDeclaration",
+                    "src": "567:15:1"
+                  }
+                ],
+                "id": 50,
+                "name": "ParameterList",
+                "src": "566:17:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "operator": "<",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "mapping(address => uint256)",
+                                  "value": "balances"
+                                },
+                                "id": 51,
+                                "name": "Identifier",
+                                "src": "592:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "member_name": "sender",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "type": "msg",
+                                      "value": "msg"
+                                    },
+                                    "id": 52,
+                                    "name": "Identifier",
+                                    "src": "601:3:1"
+                                  }
+                                ],
+                                "id": 53,
+                                "name": "MemberAccess",
+                                "src": "601:10:1"
+                              }
+                            ],
+                            "id": 54,
+                            "name": "IndexAccess",
+                            "src": "592:20:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "uint256",
+                              "value": "amount"
+                            },
+                            "id": 55,
+                            "name": "Identifier",
+                            "src": "615:6:1"
+                          }
+                        ],
+                        "id": 56,
+                        "name": "BinaryOperation",
+                        "src": "592:29:1"
+                      },
+                      {
+                        "children": [
+                          {
+                            "attributes": {
+                              "hexvalue": "66616c7365",
+                              "subdenomination": null,
+                              "token": "false",
+                              "type": "bool",
+                              "value": "false"
+                            },
+                            "id": 57,
+                            "name": "Literal",
+                            "src": "630:5:1"
+                          }
+                        ],
+                        "id": 58,
+                        "name": "Return",
+                        "src": "623:12:1"
+                      }
+                    ],
+                    "id": 59,
+                    "name": "IfStatement",
+                    "src": "588:47:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "operator": "-=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "mapping(address => uint256)",
+                                  "value": "balances"
+                                },
+                                "id": 60,
+                                "name": "Identifier",
+                                "src": "639:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "member_name": "sender",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "type": "msg",
+                                      "value": "msg"
+                                    },
+                                    "id": 61,
+                                    "name": "Identifier",
+                                    "src": "648:3:1"
+                                  }
+                                ],
+                                "id": 62,
+                                "name": "MemberAccess",
+                                "src": "648:10:1"
+                              }
+                            ],
+                            "id": 63,
+                            "name": "IndexAccess",
+                            "src": "639:20:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "uint256",
+                              "value": "amount"
+                            },
+                            "id": 64,
+                            "name": "Identifier",
+                            "src": "663:6:1"
+                          }
+                        ],
+                        "id": 65,
+                        "name": "Assignment",
+                        "src": "639:30:1"
+                      }
+                    ],
+                    "id": 66,
+                    "name": "ExpressionStatement",
+                    "src": "639:30:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "operator": "+=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "mapping(address => uint256)",
+                                  "value": "balances"
+                                },
+                                "id": 67,
+                                "name": "Identifier",
+                                "src": "673:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "type": "address",
+                                  "value": "receiver"
+                                },
+                                "id": 68,
+                                "name": "Identifier",
+                                "src": "682:8:1"
+                              }
+                            ],
+                            "id": 69,
+                            "name": "IndexAccess",
+                            "src": "673:18:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "uint256",
+                              "value": "amount"
+                            },
+                            "id": 70,
+                            "name": "Identifier",
+                            "src": "695:6:1"
+                          }
+                        ],
+                        "id": 71,
+                        "name": "Assignment",
+                        "src": "673:28:1"
+                      }
+                    ],
+                    "id": 72,
+                    "name": "ExpressionStatement",
+                    "src": "673:28:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "type": "function (address,address,uint256) constant",
+                              "value": "Transfer"
+                            },
+                            "id": 73,
+                            "name": "Identifier",
+                            "src": "705:8:1"
+                          },
+                          {
+                            "attributes": {
+                              "member_name": "sender",
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 74,
+                                "name": "Identifier",
+                                "src": "714:3:1"
+                              }
+                            ],
+                            "id": 75,
+                            "name": "MemberAccess",
+                            "src": "714:10:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "address",
+                              "value": "receiver"
+                            },
+                            "id": 76,
+                            "name": "Identifier",
+                            "src": "726:8:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "uint256",
+                              "value": "amount"
+                            },
+                            "id": 77,
+                            "name": "Identifier",
+                            "src": "736:6:1"
+                          }
+                        ],
+                        "id": 78,
+                        "name": "FunctionCall",
+                        "src": "705:38:1"
+                      }
+                    ],
+                    "id": 79,
+                    "name": "ExpressionStatement",
+                    "src": "705:38:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "hexvalue": "74727565",
+                          "subdenomination": null,
+                          "token": "true",
+                          "type": "bool",
+                          "value": "true"
+                        },
+                        "id": 80,
+                        "name": "Literal",
+                        "src": "754:4:1"
+                      }
+                    ],
+                    "id": 81,
+                    "name": "Return",
+                    "src": "747:11:1"
+                  }
+                ],
+                "id": 82,
+                "name": "Block",
+                "src": "584:178:1"
+              }
+            ],
+            "id": 83,
+            "name": "FunctionDefinition",
+            "src": "510:252:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "getBalanceInEth",
+              "payable": false,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "addr",
+                      "storageLocation": "default",
+                      "type": "address",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address"
+                        },
+                        "id": 84,
+                        "name": "ElementaryTypeName",
+                        "src": "790:7:1"
+                      }
+                    ],
+                    "id": 85,
+                    "name": "VariableDeclaration",
+                    "src": "790:12:1"
+                  }
+                ],
+                "id": 86,
+                "name": "ParameterList",
+                "src": "789:14:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint"
+                        },
+                        "id": 87,
+                        "name": "ElementaryTypeName",
+                        "src": "812:4:1"
+                      }
+                    ],
+                    "id": 88,
+                    "name": "VariableDeclaration",
+                    "src": "812:4:1"
+                  }
+                ],
+                "id": 89,
+                "name": "ParameterList",
+                "src": "811:6:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "type": "uint256",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "member_name": "convert",
+                              "type": "function (uint256,uint256) returns (uint256)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "type(library ConvertLib)",
+                                  "value": "ConvertLib"
+                                },
+                                "id": 90,
+                                "name": "Identifier",
+                                "src": "828:10:1"
+                              }
+                            ],
+                            "id": 91,
+                            "name": "MemberAccess",
+                            "src": "828:18:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "uint256",
+                              "type_conversion": false
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "type": "function (address) returns (uint256)",
+                                  "value": "getBalance"
+                                },
+                                "id": 92,
+                                "name": "Identifier",
+                                "src": "847:10:1"
+                              },
+                              {
+                                "attributes": {
+                                  "type": "address",
+                                  "value": "addr"
+                                },
+                                "id": 93,
+                                "name": "Identifier",
+                                "src": "858:4:1"
+                              }
+                            ],
+                            "id": 94,
+                            "name": "FunctionCall",
+                            "src": "847:16:1"
+                          },
+                          {
+                            "attributes": {
+                              "hexvalue": "32",
+                              "subdenomination": null,
+                              "token": null,
+                              "type": "int_const 2",
+                              "value": "2"
+                            },
+                            "id": 95,
+                            "name": "Literal",
+                            "src": "864:1:1"
+                          }
+                        ],
+                        "id": 96,
+                        "name": "FunctionCall",
+                        "src": "828:38:1"
+                      }
+                    ],
+                    "id": 97,
+                    "name": "Return",
+                    "src": "821:45:1"
+                  }
+                ],
+                "id": 98,
+                "name": "Block",
+                "src": "817:53:1"
+              }
+            ],
+            "id": 99,
+            "name": "FunctionDefinition",
+            "src": "765:105:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "getBalance",
+              "payable": false,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "addr",
+                      "storageLocation": "default",
+                      "type": "address",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address"
+                        },
+                        "id": 100,
+                        "name": "ElementaryTypeName",
+                        "src": "893:7:1"
+                      }
+                    ],
+                    "id": 101,
+                    "name": "VariableDeclaration",
+                    "src": "893:12:1"
+                  }
+                ],
+                "id": 102,
+                "name": "ParameterList",
+                "src": "892:14:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint"
+                        },
+                        "id": 103,
+                        "name": "ElementaryTypeName",
+                        "src": "915:4:1"
+                      }
+                    ],
+                    "id": 104,
+                    "name": "VariableDeclaration",
+                    "src": "915:4:1"
+                  }
+                ],
+                "id": 105,
+                "name": "ParameterList",
+                "src": "914:6:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "type": "mapping(address => uint256)",
+                              "value": "balances"
+                            },
+                            "id": 106,
+                            "name": "Identifier",
+                            "src": "932:8:1"
+                          },
+                          {
+                            "attributes": {
+                              "type": "address",
+                              "value": "addr"
+                            },
+                            "id": 107,
+                            "name": "Identifier",
+                            "src": "941:4:1"
+                          }
+                        ],
+                        "id": 108,
+                        "name": "IndexAccess",
+                        "src": "932:14:1"
+                      }
+                    ],
+                    "id": 109,
+                    "name": "Return",
+                    "src": "925:21:1"
+                  }
+                ],
+                "id": 110,
+                "name": "Block",
+                "src": "921:29:1"
+              }
+            ],
+            "id": 111,
+            "name": "FunctionDefinition",
+            "src": "873:77:1"
+          }
+        ],
+        "id": 112,
+        "name": "ContractDefinition",
+        "src": "315:637:1"
+      }
+    ],
+    "name": "SourceUnit"
+  },
+  "address": "0x4a5092ae2f237d76f25691fff90955545ba2dc78",
+  "networks": {
+    "1494889277189": {
+      "address": "0x657b316c4c7df70999a69c2475e59152f87a04aa",
+      "links": {
+        "ConvertLib": {
+          "address": "0x7bcc63d45790e23f6e9bc3514e1ab5af649302d0",
+          "events": {
+            "0xa163a6249e860c278ef4049759a7f7c7e8c141d30fd634fda9b5a6a95d111a30": {
+              "anonymous": false,
+              "inputs": [],
+              "name": "Test",
+              "type": "event"
+            }
+          }
+        }
+      }
+    }
+  },
+  "updatedAt": "2017-05-15T20:46:00Z",
+  "schemaVersion": "0.0.5"
+}

--- a/test/options.js
+++ b/test/options.js
@@ -7,9 +7,6 @@ describe("options", function() {
       "x-from-dependency": "adder/Adder.sol"
     }
 
-    options = Schema.normalizeInput(options);
-    assert.equal(options["x-from-dependency"], "adder/Adder.sol");
-
     options = Schema.generateObject(options);
     assert.equal(options["x-from-dependency"], "adder/Adder.sol");
 

--- a/test/options.js
+++ b/test/options.js
@@ -7,10 +7,7 @@ describe("options", function() {
       "x-from-dependency": "adder/Adder.sol"
     }
 
-    options = Schema.generateObject(options);
+    options = Schema.normalize(options);
     assert.equal(options["x-from-dependency"], "adder/Adder.sol");
-
-    options = Schema.generateObject(options, {"x-another-option": "exists"});
-    assert.equal(options["x-another-option"], "exists");
   });
 });

--- a/test/options.js
+++ b/test/options.js
@@ -7,13 +7,13 @@ describe("options", function() {
       "x-from-dependency": "adder/Adder.sol"
     }
 
-    options = Schema.normalizeOptions(options);
+    options = Schema.normalizeInput(options);
     assert.equal(options["x-from-dependency"], "adder/Adder.sol");
 
-    options = Schema.generateBinary(options);
+    options = Schema.generateObject(options);
     assert.equal(options["x-from-dependency"], "adder/Adder.sol");
 
-    options = Schema.generateBinary(options, {"x-another-option": "exists"});
+    options = Schema.generateObject(options, {"x-another-option": "exists"});
     assert.equal(options["x-another-option"], "exists");
   });
 });

--- a/test/schema.js
+++ b/test/schema.js
@@ -28,26 +28,23 @@ describe("Schema", function() {
     assert.ifError(validator.errors);
   });
 
-  it("returns a validation promise with successful `then` behavior", function(done) {
+  it("validates correct input", function() {
     Schema.validate(MetaCoin)
-      .then(function() {
-        done();
-      });
   });
 
-  it("returns a validation promise with successful `catch` behavior", function(done) {
+  it("throws exception on invalid input", function() {
     var invalid = {
       "abi": -1
     };
 
-    Schema.validate(invalid)
-      .catch(function(errors) {
-        var abiErrors = errors.filter(function(error) {
-          return error.dataPath === ".abi"
-        });
-        assert(abiErrors);
-        done();
+    try {
+      Schema.validate(invalid)
+    } catch (errors) {
+      var abiErrors = errors.filter(function(error) {
+        return error.dataPath === ".abi"
       });
+      assert(abiErrors);
+    }
   });
 
 });

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,0 +1,30 @@
+var fs = require("fs");
+var spec = require("../spec/contract.spec.json");
+var Ajv = require("ajv");
+var assert = require("assert");
+
+var MetaCoinJSON = require("./MetaCoin.json");
+
+describe("Schema", function() {
+  var validator;
+  var invalidSchemaError;
+
+  before("load schema library", function() {
+    var ajv = new Ajv();
+    try {
+      validator = ajv.compile(spec);
+    } catch (e) {
+      invalidSchemaError = e;
+    }
+  });
+
+  it("validates as json-schema", function() {
+    assert.ifError(invalidSchemaError);
+  });
+
+  it("validates a simple example", function() {
+    var valid = validator(MetaCoinJSON);
+    assert.ifError(validator.errors);
+  });
+
+});

--- a/test/schema.js
+++ b/test/schema.js
@@ -37,15 +37,15 @@ describe("Schema", function() {
 
   it("returns a validation promise with successful `catch` behavior", function(done) {
     var invalid = {
-      "address": -1
+      "abi": -1
     };
 
     Schema.validate(invalid)
       .catch(function(errors) {
-        var addressErrors = errors.filter(function(error) {
-          return error.dataPath === ".address"
+        var abiErrors = errors.filter(function(error) {
+          return error.dataPath === ".abi"
         });
-        assert(addressErrors);
+        assert(abiErrors);
         done();
       });
   });

--- a/test/schema.js
+++ b/test/schema.js
@@ -2,8 +2,9 @@ var fs = require("fs");
 var spec = require("../spec/contract.spec.json");
 var Ajv = require("ajv");
 var assert = require("assert");
+var Schema = require("../index.js");
 
-var MetaCoinJSON = require("./MetaCoin.json");
+var MetaCoin = require("./MetaCoin.json");
 
 describe("Schema", function() {
   var validator;
@@ -23,8 +24,30 @@ describe("Schema", function() {
   });
 
   it("validates a simple example", function() {
-    var valid = validator(MetaCoinJSON);
+    var valid = validator(MetaCoin);
     assert.ifError(validator.errors);
+  });
+
+  it("returns a validation promise with successful `then` behavior", function(done) {
+    Schema.validateContractObject(MetaCoin)
+      .then(function() {
+        done();
+      });
+  });
+
+  it("returns a validation promise with successful `catch` behavior", function(done) {
+    var invalid = {
+      "address": -1
+    };
+
+    Schema.validateContractObject(invalid)
+      .catch(function(errors) {
+        var addressErrors = errors.filter(function(error) {
+          return error.dataPath === ".address"
+        });
+        assert(addressErrors);
+        done();
+      });
   });
 
 });

--- a/test/schema.js
+++ b/test/schema.js
@@ -29,7 +29,7 @@ describe("Schema", function() {
   });
 
   it("returns a validation promise with successful `then` behavior", function(done) {
-    Schema.validateContractObject(MetaCoin)
+    Schema.validate(MetaCoin)
       .then(function() {
         done();
       });
@@ -40,7 +40,7 @@ describe("Schema", function() {
       "address": -1
     };
 
-    Schema.validateContractObject(invalid)
+    Schema.validate(invalid)
       .catch(function(errors) {
         var addressErrors = errors.filter(function(error) {
           return error.dataPath === ".address"

--- a/test/solc.js
+++ b/test/solc.js
@@ -38,7 +38,7 @@ describe("solc", function() {
     // contracts now grouped by solidity source file
     var rawA = JSON.parse(solcOut).contracts["A.sol"].A;
 
-    var A = Schema.generateObject({}, rawA);
+    var A = Schema.generateObject(rawA);
 
     var expected = {
       abi: rawA.abi,
@@ -61,7 +61,7 @@ describe("solc", function() {
     });
 
     return Schema
-      .validateContractObject(A)
+      .validate(A)
       .catch(function (errors) {
         assert.ifError(errors);
       });

--- a/test/solc.js
+++ b/test/solc.js
@@ -11,7 +11,7 @@ describe("solc", function() {
 
     var data = result.contracts[":A"];
 
-    var A = Schema.generateObject(data);
+    var A = Schema.normalize(data);
 
     assert.deepEqual(A.abi, JSON.parse(data.interface));
     assert.equal(A.bytecode, "0x" + data.bytecode);
@@ -38,7 +38,7 @@ describe("solc", function() {
     // contracts now grouped by solidity source file
     var rawA = JSON.parse(solcOut).contracts["A.sol"].A;
 
-    var A = Schema.generateObject(rawA);
+    var A = Schema.normalize(rawA);
 
     var expected = {
       abi: rawA.abi,

--- a/test/solc.js
+++ b/test/solc.js
@@ -22,7 +22,7 @@ describe("solc", function() {
     done();
   });
 
-  it("processes solc compileStandard output correctly", function() {
+  it("processes solc compileStandard output correctly", function(done) {
     this.timeout(5000);
 
     var solcIn = JSON.stringify({
@@ -60,10 +60,8 @@ describe("solc", function() {
       );
     });
 
-    return Schema
-      .validate(A)
-      .catch(function (errors) {
-        assert.ifError(errors);
-      });
+    // throws error if invalid
+    Schema.validate(A);
+    done();
   });
 });

--- a/test/solc.js
+++ b/test/solc.js
@@ -1,0 +1,22 @@
+var assert = require("assert");
+var solc = require("solc");
+var Schema = require("../");
+
+describe("solc", function() {
+  it("Will save files using input directly from solc", function(done) {
+    this.timeout(5000);
+    var result = solc.compile("contract A { function doStuff() {} } \n\n contract B { function somethingElse() {} }", 1);
+
+    var data = result.contracts[":A"];
+
+    var A = Schema.generateObject(data);
+
+    assert.deepEqual(A.abi, JSON.parse(data.interface));
+    assert.equal(A.bytecode, "0x" + data.bytecode);
+    assert.equal(A.deployedBytecode, "0x" + data.runtimeBytecode);
+    assert.equal(A.sourceMap, data.srcmap);
+    assert.equal(A.deployedSourceMap, data.srcmapRuntime);
+
+    done();
+  });
+});


### PR DESCRIPTION
*"Don't avert your eyes; normalize!"*

Ref: #1

#### Herein:

N.B. this work involves several breaking changes and will require a major release.

- Define json-schema specification of contract objects
- Match `bytecode`/`deployedBytecode` convention from newer solc, replacing `runtimeBinary`, `srcmapRuntime`, etc.
- Rename snake_case properties to their camelCase equivalents:
    - `contract_name` -> `contractName`
    - `updated_at` -> `updatedAt`
    - `schema_version` -> `schemaVersion`
- Update Schema module to expose the following behaviors:
    - `validate(obj)` returns `bool`
    - `normalize(objDirty)` returns `obj`
- (Remove `generateObject`)
- Ensure contract objects are safely and correctly generated from all kinds of different sources ("dirty" objects), namely:
    - Previous versions' contract object JSON files (with different keys, etc.)
    - `truffle-contract` abstraction classes or instances
    - `solc` output either from `.compile` or `.compileStandard`
    - Contract objects that already match the standard
- Use ISO8601 timestamp for `updatedAt`


#### Normalization approach:

- Reimplement contract object normalization with declarative description of translation:
    - Define properties as single canonical output key, sourced from one of multiple alternative input keys.
    - Ensure that normalization happens as part of a single-pass operation over this translation description. 
- Eliminate "flat-object"-style input (no more top-level `address`, `network_id`, `links`, `events`!)