### PR TITLE
Add transaction id in contract schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Version of this schema used by contract object representation.
 
 | type | _string_ |
 | ---: | ---- |
-| format | IS0-8601 Datetime |
+| type | IS0-8601 Datetime |
 
 
 Time at which contract object representation was generated/most recently
@@ -165,6 +165,15 @@ updated.
 Listing of contract instances. Object mapping network ID keys to network object
 values. Includes address information, links to other contract instances, and/or
 contract event logs.
+
+### `transactionId`
+
+| type | _string_ |
+| ---: | ---- |
+| pattern | ^0x[a-fA-F0-9]{64}$ |
+
+
+The hash of the transaction.
 
 #### Properties (key matching `^[a-zA-Z0-9]+$`)
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,15 @@ var properties = {
       }
       return value;
     }
+  },
+  "transactionId": {
+    "sources": ["transactionHash"],
+    "transform": function(value) {
+      if (value && value.indexOf("0x") != 0) {
+        value = "0x" + value;
+      }
+      return value;
+    }
   }
 };
 

--- a/spec/contract-object.spec.json
+++ b/spec/contract-object.spec.json
@@ -65,6 +65,10 @@
     "updatedAt": {
       "type": "string",
       "format": "date-time"
+    },
+    "transactionId": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]{64}$"
     }
   },
   "required": [


### PR DESCRIPTION
I just saw this issue https://github.com/trufflesuite/truffle/issues/472 and try to add transaction id in contract schema.

After trace the source code, I saw this `contract.address = instance.address` https://github.com/trufflesuite/truffle-deployer/blob/develop/src/actions/deploy.js#L37, maybe should add `contract.transactionHash=instance.transactionHash` to ensure the transactionHash is set on the contract?

Thanks!