### PR TITLE
Provide support for legacyAST and new AST

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,9 +79,13 @@ var properties = {
   "ast": {},
   "legacyAST": {
     "transform": function(value, obj) {
+      var schemaVersion = obj.schemaVersion || "0.0.0";
+
       // legacyAST introduced in v2.0.0
-      if (obj.schemaVersion[0] < 2) {
+      if (schemaVersion[0] < 2) {
         return obj.ast;
+      } else {
+        return value
       }
     }
   },

--- a/index.js
+++ b/index.js
@@ -77,6 +77,14 @@ var properties = {
   "source": {},
   "sourcePath": {},
   "ast": {},
+  "legacyAST": {
+    "transform": function(value, obj) {
+      // legacyAST introduced in v2.0.0
+      if (obj.schemaVersion[0] < 2) {
+        return obj.ast;
+      }
+    }
+  },
   "compiler": {},
   "networks": {
     "transform": function(value) {
@@ -195,7 +203,7 @@ var TruffleContractSchema = {
       // run source-agnostic transform on value
       // (e.g. make sure bytecode begins 0x)
       if (property.transform) {
-        value = property.transform(value);
+        value = property.transform(value, objDirty);
       }
 
       // add resulting (possibly undefined) to normalized obj

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "homepage": "https://github.com/trufflesuite/truffle-schema#readme",
   "dependencies": {
     "ajv": "^5.1.1",
-    "crypto-js": "^3.1.9-1"
+    "crypto-js": "^3.1.9-1",
+    "debug": "^3.1.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0",

--- a/spec/contract-object.spec.json
+++ b/spec/contract-object.spec.json
@@ -48,6 +48,7 @@
     "source": { "$ref": "#/definitions/Source" },
     "sourcePath": { "$ref": "#/definitions/SourcePath" },
     "ast": { "$ref": "#/definitions/AST" },
+    "legacyAST": { "$ref": "#/definitions/LegacyAST" },
     "compiler": {
       "type": "object",
       "properties": {
@@ -107,6 +108,10 @@
     },
 
     "AST": {
+      "type": "object"
+    },
+
+    "LegacyAST": {
       "type": "object"
     },
 

--- a/test/solc.js
+++ b/test/solc.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var solc = require("solc");
 var Schema = require("../");
+var debug = require("debug")("test:solc");
 
 describe("solc", function() {
   var exampleSolidity = "contract A { function doStuff() {} } \n\n contract B { function somethingElse() {} }";
@@ -31,12 +32,25 @@ describe("solc", function() {
         "A.sol": {
           "content": exampleSolidity
         }
+      },
+      settings: {
+        outputSelection: {
+          "*": {
+            "*": [
+              "abi",
+              "evm.bytecode.object",
+              "evm.bytecode.sourceMap",
+              "evm.deployedBytecode.object",
+              "evm.deployedBytecode.sourceMap"
+            ]
+          }
+        }
       }
     });
-    var solcOut = solc.compileStandard(solcIn);
+    var solcOut = JSON.parse(solc.compileStandard(solcIn));
 
     // contracts now grouped by solidity source file
-    var rawA = JSON.parse(solcOut).contracts["A.sol"].A;
+    var rawA = solcOut.contracts["A.sol"].A;
 
     var A = Schema.normalize(rawA);
 


### PR DESCRIPTION
- Make `ast` refer to the new AST, `legacyAST` refer to the legacy AST
- Update `normalize()` to populate `legacyAST` for old schema versions.